### PR TITLE
サービスプリンシパルでの認証に対応する

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,55 @@ jobs:
 
 ---
 
+## 認証方法
+
+認証方法は 2 つあり、どちらか一方を指定します。
+
+### サービスプリンシパル（推奨）
+
+サービスプリンシパルでは、長期的な秘密である RSA 秘密鍵は利用者側に置いたままで、
+実際に送信するのは有効期限 5 分の署名付きアサーションだけです。
+これをさくらのクラウドのトークンエンドポイントに送り、有効期間 1 時間のアクセストークンと交換します。
+
+事前にコントロールパネルで公開鍵を登録し、リソース ID と KID を控えてください。
+詳細は[サービスプリンシパルのマニュアル](https://manual.sakura.ad.jp/cloud/controlpanel/service-principal.html)を参照してください。
+
+```yaml
+- uses: sundaypeople/sakura-apprun-deploy@v0.0.8
+  with:
+    service_principal_resource_id: ${{ secrets.SAKURACLOUD_SP_RESOURCE_ID }}
+    service_principal_kid: ${{ secrets.SAKURACLOUD_SP_KID }}
+    service_principal_private_key: ${{ secrets.SAKURACLOUD_SP_PRIVATE_KEY }}
+    application_name: my-app
+    image: registry.example.com/namespace/my-app:latest
+```
+
+* `service_principal_private_key` は PEM そのままでも、PEM を base64 で 1 行にエンコードしたものでも受け付けます。
+* サービスプリンシパルの 3 つの入力は必ずまとめて指定してください。一部だけ指定した場合はエラーになります。
+* 取得したアクセストークンは `setSecret` でマスクされ、ログには出力されません。
+
+### API キー
+
+```yaml
+- uses: sundaypeople/sakura-apprun-deploy@v0.0.8
+  with:
+    access_token: ${{ secrets.APPRUN_ACCESS_TOKEN }}
+    access_secret: ${{ secrets.APPRUN_ACCESS_SECRET }}
+    application_name: my-app
+    image: registry.example.com/namespace/my-app:latest
+```
+
+> ℹ️ 両方を指定した場合はサービスプリンシパルが優先され、`access_token` / `access_secret` は無視されます。
+
 ## Inputs（入力）
 
 | 名前                         | 必須 | 説明                                                                           |
 |----------------------------|:--:|------------------------------------------------------------------------------|
-| `access_token`             | ✔︎ | Apprun の API アクセストークン                                                        |
-| `access_secret`            | ✔︎ | Apprun の API アクセスシークレット                                                      |
+| `access_token`             | ※ | Apprun の API アクセストークン（サービスプリンシパル利用時は不要）                                      |
+| `access_secret`            | ※ | Apprun の API アクセスシークレット（サービスプリンシパル利用時は不要）                                    |
+| `service_principal_resource_id` | ※ | サービスプリンシパルのリソース ID（3 つまとめて指定）                                            |
+| `service_principal_kid`    | ※ | 公開鍵登録時に払い出された鍵 ID（KID）                                                       |
+| `service_principal_private_key` | ※ | サービスプリンシパルの RSA 秘密鍵（PEM、または PEM を base64 エンコードしたもの）                     |
 | `application_name`         | ✔︎ | アプリケーション名（作成/更新のキー）                                                          |
 | `port`                     |    | アプリがリッスンするポート番号                                                              |
 | `image`                    | ✔︎ | デプロイするコンテナイメージ（例: `registry.example.com/ns/app:tag`）                         |
@@ -132,6 +175,10 @@ jobs:
 | `inherit_env`              | 　　| 更新時にサービス環境変数を一つ前のから継承（true / false） |
 | `packet_filter_enabled`    |    | パケットフィルターの有効化（true / false）                                                  |
 | `packet_filter_allowlist`  |    | 許可する送信元 CIDR のリスト（改行区切り）                                                     |
+
+> ℹ️ **※ の入力について**
+> 認証に使うため、`access_token` + `access_secret` の組か、`service_principal_*` の 3 つの組の
+> **どちらか一方**が必須です。詳しくは [認証方法](#認証方法) を参照してください。
 
 > ℹ️ **YAML マップ入力について**
 > `env` と `probe_headers` は YAML を **キー/値のマップ**で記述します。

--- a/__tests__/service-principal.test.ts
+++ b/__tests__/service-principal.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { createVerify, generateKeyPairSync } from 'node:crypto';
+import { createAssertion, fetchAccessToken, TOKEN_ENDPOINT } from '../src/service-principal';
+import { getCredentials, normalizePrivateKey } from '../src/actions-configration';
+
+const { privateKey, publicKey } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+const principal = {
+  resourceId: '123456789012',
+  kid: 'kid-abcdef',
+  privateKey,
+};
+
+function decodeSegment(segment: string): Record<string, unknown> {
+  return JSON.parse(Buffer.from(segment.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8'));
+}
+
+describe('createAssertion', () => {
+  it('produces a three part JWS', () => {
+    expect(createAssertion(principal, 1_700_000_000).split('.')).toHaveLength(3);
+  });
+
+  it('sets the header fields required by the manual', () => {
+    const [header] = createAssertion(principal, 1_700_000_000).split('.');
+    expect(decodeSegment(header)).toEqual({ alg: 'RS256', kid: 'kid-abcdef', typ: 'JWT' });
+  });
+
+  it('sets the claims required by the manual', () => {
+    const now = 1_700_000_000;
+    const [, payload] = createAssertion(principal, now).split('.');
+    expect(decodeSegment(payload)).toEqual({
+      aud: TOKEN_ENDPOINT,
+      exp: now + 300,
+      iat: now,
+      iss: principal.resourceId,
+      sub: principal.resourceId,
+    });
+  });
+
+  it('expires within five minutes', () => {
+    const now = 1_700_000_000;
+    const [, payload] = createAssertion(principal, now).split('.');
+    const claims = decodeSegment(payload) as { exp: number; iat: number };
+    expect(claims.exp - claims.iat).toBeLessThanOrEqual(300);
+  });
+
+  it('signs the assertion so the public key can verify it', () => {
+    const assertion = createAssertion(principal, 1_700_000_000);
+    const [header, payload, signature] = assertion.split('.');
+    const verifier = createVerify('RSA-SHA256');
+    verifier.update(`${header}.${payload}`);
+    verifier.end();
+    expect(verifier.verify(publicKey, Buffer.from(signature.replace(/-/g, '+').replace(/_/g, '/'), 'base64'))).toBe(true);
+  });
+
+  it('emits base64url without padding', () => {
+    expect(createAssertion(principal, 1_700_000_000)).not.toMatch(/[+/=]/);
+  });
+
+  it('fails with a clear message when the key is not usable', () => {
+    expect(() => createAssertion({ ...principal, privateKey: 'not a key' }, 1)).toThrow(/service principal private key/);
+  });
+});
+
+describe('normalizePrivateKey', () => {
+  it('passes a PEM through unchanged', () => {
+    expect(normalizePrivateKey(`  ${privateKey}  `)).toBe(privateKey.trim());
+  });
+
+  it('decodes a base64 encoded PEM', () => {
+    expect(normalizePrivateKey(Buffer.from(privateKey).toString('base64'))).toBe(privateKey.trim());
+  });
+
+  it('rejects anything that is not a private key', () => {
+    expect(() => normalizePrivateKey('aGVsbG8=')).toThrow(/PEM private key/);
+  });
+});
+
+describe('fetchAccessToken', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('exchanges a jwt-bearer assertion for the access token', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ access_token: 'issued-token', token_type: 'Bearer', expires_in: 3600 }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    expect(await fetchAccessToken(principal)).toBe('issued-token');
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe(TOKEN_ENDPOINT);
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/x-www-form-urlencoded');
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get('grant_type')).toBe('urn:ietf:params:oauth:grant-type:jwt-bearer');
+    expect(body.get('assertion')?.split('.')).toHaveLength(3);
+  });
+
+  it('reports the status and the body when the endpoint rejects the assertion', async () => {
+    vi.stubGlobal('fetch', async () => new Response('{"error":"invalid_grant"}', { status: 400, statusText: 'Bad Request' }));
+    await expect(fetchAccessToken(principal)).rejects.toThrow(/status 400 .*invalid_grant/s);
+  });
+
+  it('fails when the response carries no access token', async () => {
+    vi.stubGlobal('fetch', async () => new Response('{"token_type":"Bearer"}', { status: 200 }));
+    await expect(fetchAccessToken(principal)).rejects.toThrow(/did not return an access token/);
+  });
+});
+
+describe('getCredentials', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  function stubServicePrincipal(key: string = privateKey) {
+    vi.stubEnv('INPUT_SERVICE_PRINCIPAL_RESOURCE_ID', principal.resourceId);
+    vi.stubEnv('INPUT_SERVICE_PRINCIPAL_KID', principal.kid);
+    vi.stubEnv('INPUT_SERVICE_PRINCIPAL_PRIVATE_KEY', key);
+  }
+
+  it('reads the service principal inputs', () => {
+    stubServicePrincipal();
+    expect(getCredentials()).toEqual({
+      kind: 'servicePrincipal',
+      principal: { resourceId: principal.resourceId, kid: principal.kid, privateKey: privateKey.trim() },
+    });
+  });
+
+  it('accepts a base64 encoded private key', () => {
+    stubServicePrincipal(Buffer.from(privateKey).toString('base64'));
+    expect(getCredentials()).toEqual({
+      kind: 'servicePrincipal',
+      principal: { resourceId: principal.resourceId, kid: principal.kid, privateKey: privateKey.trim() },
+    });
+  });
+
+  it('rejects a partially configured service principal', () => {
+    vi.stubEnv('INPUT_SERVICE_PRINCIPAL_RESOURCE_ID', principal.resourceId);
+    vi.stubEnv('INPUT_SERVICE_PRINCIPAL_KID', principal.kid);
+    expect(() => getCredentials()).toThrow(/must be set together/);
+  });
+
+  it('falls back to the API key when no service principal is configured', () => {
+    vi.stubEnv('INPUT_ACCESS_TOKEN', 'access-token');
+    vi.stubEnv('INPUT_ACCESS_SECRET', 'access-secret');
+    expect(getCredentials()).toEqual({ kind: 'apiKey', access: { token: 'access-token', secret: 'access-secret' } });
+  });
+
+  it('names both authentication methods when nothing is configured', () => {
+    expect(() => getCredentials()).toThrow(/set either access_token and access_secret, or service_principal_/);
+  });
+
+  it('still reports the missing half of an incomplete API key', () => {
+    vi.stubEnv('INPUT_ACCESS_SECRET', 'access-secret');
+    expect(() => getCredentials()).toThrow(/access_token/);
+  });
+
+  it('prefers the service principal when both are configured', () => {
+    stubServicePrincipal();
+    vi.stubEnv('INPUT_ACCESS_TOKEN', 'access-token');
+    vi.stubEnv('INPUT_ACCESS_SECRET', 'access-secret');
+    expect(getCredentials()).toMatchObject({ kind: 'servicePrincipal' });
+  });
+});

--- a/action.yaml
+++ b/action.yaml
@@ -3,11 +3,20 @@ description: Registers and deploys the application to Apprun
 
 inputs:
   access_token:
-    description: 'API access token'
-    required: true
+    description: 'API access token (not needed when using a service principal)'
+    required: false
   access_secret:
-    description: 'API access secret'
-    required: true
+    description: 'API access secret (not needed when using a service principal)'
+    required: false
+  service_principal_resource_id:
+    description: 'Resource ID of the service principal. Set together with service_principal_kid and service_principal_private_key.'
+    required: false
+  service_principal_kid:
+    description: 'Key ID (KID) assigned when the service principal public key was registered'
+    required: false
+  service_principal_private_key:
+    description: 'RSA private key of the service principal, as PEM or as base64-encoded PEM'
+    required: false
   application_name:
     description: 'The name of Apprun application'
     required: true

--- a/src/actions-configration.ts
+++ b/src/actions-configration.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import { getBooleanInput, getInput } from '@actions/core';
 import * as model from './model';
 import * as yaml from 'js-yaml';
@@ -73,6 +74,58 @@ export function getAPIKey(): model.Access {
     throw new Error('Both access-token and access-secret are required');
   }
   return { token: accessToken, secret: accessSecret };
+}
+
+/**
+ * Read credentials, preferring a service principal when one is configured.
+ *
+ * A service principal keeps the long-lived secret (the RSA private key) on the
+ * caller side and only ever sends a 5-minute assertion, so it is the preferred
+ * way to authenticate from CI. The API key inputs remain supported.
+ */
+export function getCredentials(): model.Credentials {
+  const resourceId = getStringInputUndefined('service_principal_resource_id', true);
+  const kid = getStringInputUndefined('service_principal_kid', true);
+  const privateKeyInput = getStringInputUndefined('service_principal_private_key', false);
+
+  if (typeof resourceId === 'string' && typeof kid === 'string' && typeof privateKeyInput === 'string') {
+    return {
+      kind: 'servicePrincipal',
+      principal: {
+        resourceId: resourceId,
+        kid: kid,
+        privateKey: normalizePrivateKey(privateKeyInput),
+      },
+    };
+  }
+  if (typeof resourceId !== 'undefined' || typeof kid !== 'undefined' || typeof privateKeyInput !== 'undefined') {
+    throw new Error('service_principal_resource_id, service_principal_kid and service_principal_private_key must be set together');
+  }
+
+  // Neither authentication method was configured at all. Point at both of them
+  // rather than letting getAPIKey report only the missing access_token.
+  if (typeof getStringInputUndefined('access_token', true) === 'undefined' && typeof getStringInputUndefined('access_secret', true) === 'undefined') {
+    throw new Error('No credentials were supplied: set either access_token and access_secret, or service_principal_resource_id, service_principal_kid and service_principal_private_key');
+  }
+
+  return { kind: 'apiKey', access: getAPIKey() };
+}
+
+/**
+ * Accept the private key either as a PEM or as a single-line base64 encoding of
+ * one. Multi-line secrets survive GitHub Actions fine, but base64 is easier to
+ * paste around without breaking the newlines.
+ */
+export function normalizePrivateKey(input: string): string {
+  const trimmed = input.trim();
+  if (trimmed.includes('-----BEGIN')) {
+    return trimmed;
+  }
+  const decoded = Buffer.from(trimmed, 'base64').toString('utf8');
+  if (!decoded.includes('-----BEGIN')) {
+    throw new Error('service_principal_private_key must be a PEM private key, or that PEM encoded as base64');
+  }
+  return decoded.trim();
 }
 
 export function getCreateConfig(applicationName: string): [model.CreateApplicationRequest, model.PatchPacketFilterRequest, boolean] {

--- a/src/apprun-client.ts
+++ b/src/apprun-client.ts
@@ -2,12 +2,19 @@ import { Buffer } from 'node:buffer';
 import * as model from './model';
 
 const URL = 'https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/';
-interface AppRunClient {
+export interface AppRunClient {
   authHeader: string;
 }
 export const apprunClient = (accessToken: string, accessSecret: string): AppRunClient => {
   return {
     authHeader: 'Basic ' + Buffer.from(`${accessToken}:${accessSecret}`).toString('base64'),
+  };
+};
+
+/** Client authenticated with a service principal bearer token. */
+export const apprunBearerClient = (accessToken: string): AppRunClient => {
+  return {
+    authHeader: `Bearer ${accessToken}`,
   };
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,20 @@
-import { setOutput, setFailed } from '@actions/core';
-import { apprunClient, getAllApplication, patchPacketFilter, createApplication, getApplication, patchApplication } from './apprun-client';
-import { getAPIKey, getConfig, replaceEnv, replaceSecret } from './actions-configration';
+import { setOutput, setFailed, setSecret } from '@actions/core';
+import { AppRunClient, apprunBearerClient, apprunClient, getAllApplication, patchPacketFilter, createApplication, getApplication, patchApplication } from './apprun-client';
+import { getConfig, getCredentials, replaceEnv, replaceSecret } from './actions-configration';
+import { fetchAccessToken } from './service-principal';
 import * as model from './model';
 
 export async function run(): Promise<void> {
   try {
-    const keys = getAPIKey();
-    const client = apprunClient(keys.token, keys.secret);
+    const credentials = getCredentials();
+    let client: AppRunClient;
+    if (credentials.kind === 'servicePrincipal') {
+      const accessToken = await fetchAccessToken(credentials.principal);
+      setSecret(accessToken);
+      client = apprunBearerClient(accessToken);
+    } else {
+      client = apprunClient(credentials.access.token, credentials.access.secret);
+    }
 
     const applications = await getAllApplication(client);
     const nameToIdMap = new Map<string, string>();

--- a/src/model.ts
+++ b/src/model.ts
@@ -147,6 +147,15 @@ export interface Access {
   secret: string;
 }
 
+export interface ServicePrincipalAccess {
+  resourceId: string;
+  kid: string;
+  privateKey: string;
+}
+
+/** Either an API key or a service principal. */
+export type Credentials = { kind: 'apiKey'; access: Access } | { kind: 'servicePrincipal'; principal: ServicePrincipalAccess };
+
 export interface GetAllApplicationResponse {
   data: Array<{
     id: string;

--- a/src/service-principal.ts
+++ b/src/service-principal.ts
@@ -1,0 +1,94 @@
+/**
+ * Service principal authentication for SAKURA Cloud.
+ *
+ * Instead of an API key (access token / secret), a service principal signs a
+ * short-lived JWT with its RSA private key and exchanges it for a bearer token.
+ *
+ *   1. Build a JWT: header { alg: RS256, kid: <KID>, typ: JWT },
+ *      payload { iss, sub: <resource id>, aud: <token endpoint>, iat, exp }.
+ *   2. POST it to the token endpoint as an RFC 7523 jwt-bearer assertion.
+ *   3. Use the returned access token as `Authorization: Bearer <token>`.
+ *
+ * See https://manual.sakura.ad.jp/cloud/controlpanel/service-principal.html
+ */
+import { Buffer } from 'node:buffer';
+import { createSign } from 'node:crypto';
+
+export const TOKEN_ENDPOINT = 'https://secure.sakura.ad.jp/cloud/api/iam/1.0/service-principals/oauth2/token';
+
+/** The private key must not outlive the request by much; the doc allows 5 minutes. */
+const ASSERTION_LIFETIME_SECONDS = 300;
+
+export interface ServicePrincipal {
+  /** Resource ID of the service principal. Used as both `iss` and `sub`. */
+  resourceId: string;
+  /** Key ID assigned when the public key was registered. */
+  kid: string;
+  /** RSA private key in PEM format (PKCS#1 or PKCS#8). */
+  privateKey: string;
+}
+
+export interface TokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in?: number;
+  token_expired_at?: string;
+}
+
+function base64url(input: Buffer | string): string {
+  return Buffer.from(input).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * Build the signed assertion. Exported so it can be tested without network access.
+ *
+ * @param principal service principal credentials
+ * @param now       current time in seconds since the epoch (injectable for tests)
+ */
+export function createAssertion(principal: ServicePrincipal, now: number = Math.floor(Date.now() / 1000)): string {
+  const header = { alg: 'RS256', kid: principal.kid, typ: 'JWT' };
+  const payload = {
+    aud: TOKEN_ENDPOINT,
+    exp: now + ASSERTION_LIFETIME_SECONDS,
+    iat: now,
+    iss: principal.resourceId,
+    sub: principal.resourceId,
+  };
+  const signingInput = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(payload))}`;
+
+  const signer = createSign('RSA-SHA256');
+  signer.update(signingInput);
+  signer.end();
+  let signature: Buffer;
+  try {
+    signature = signer.sign(principal.privateKey);
+  } catch (error) {
+    throw new Error(`Failed to sign the assertion with the service principal private key: ${(error as Error).message}`, { cause: error });
+  }
+  return `${signingInput}.${base64url(signature)}`;
+}
+
+/** Exchange a signed assertion for a bearer access token. */
+export async function fetchAccessToken(principal: ServicePrincipal): Promise<string> {
+  const body = new URLSearchParams({
+    grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+    assertion: createAssertion(principal),
+  });
+
+  const response = await fetch(TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+
+  if (response.status >= 400) {
+    const errorText = await response.text();
+    throw new Error(`Failed to obtain a service principal access token — status ${response.status} ${response.statusText} — URL: ${TOKEN_ENDPOINT} — Response: ${errorText}`);
+  }
+
+  const token = (await response.json()) as TokenResponse;
+  if (!token.access_token) {
+    throw new Error(`The token endpoint did not return an access token — URL: ${TOKEN_ENDPOINT}`);
+  }
+  return token.access_token;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
+    "lib": ["ES2022", "DOM"],
     "module": "esnext",
     "moduleResolution": "bundler",
     "strict": true,


### PR DESCRIPTION
API キー（access_token / access_secret）に加えて、さくらのクラウドのサービスプリンシパルで認証できるようにした。
CI 側に長期の共有シークレットを置かずに済み、送るのは 5 分で切れる署名付きアサーションだけになる。

- src/service-principal.ts: RS256 で JWT を署名し、jwt-bearer グラントでアクセストークンへ交換する（node:crypto のみ。依存は増やしていない）
- 入力 service_principal_resource_id / _kid / _private_key を追加。秘密鍵は PEM でも base64 の 1 行でも受け付ける
- 3 つのうち一部だけ指定された場合はエラーにする
- 認証情報を一つも指定しなかった場合は、API キーとサービスプリンシパルのどちらかが必要である旨をエラーで示す（従来は access_token が無い、としか出なかった）
- 取得したアクセストークンは setSecret でログからマスクする
- access_token / access_secret は required: false へ（後方互換。両方指定された場合はサービスプリンシパルを優先する）
- tsconfig: Error の cause を使うため lib に ES2022 を追加

エンドポイント・ヘッダ・クレーム・有効期限はサービスプリンシパルのマニュアルの記載に合わせている。
https://manual.sakura.ad.jp/cloud/controlpanel/service-principal.html
